### PR TITLE
[Fix Docker Builds #334] changed the dockerfile path in docker.yaml workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
     branches:
      - 'main'
      - 'banjofox/*'
+  workflow_dispatch: # added for testing 
 
 jobs:
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file docker/Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,6 @@ on:
     branches:
      - 'main'
      - 'banjofox/*'
-  workflow_dispatch: # added for testing 
 
 jobs:
 

--- a/aardwolf-yew-frontend/Cargo.toml
+++ b/aardwolf-yew-frontend/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.21.0", features = ["csr"]}
-yew-router = "0.18.0"
+yew = { version = "^0.21.0", features = ["csr"]}
+yew-router = "^0.18.0"
 wasm-bindgen = "0.2.93" # Easy support for interacting between JS and Rust.
 log = {version = "0.4.22", features = ["std", "serde"]} # Also used by main app for logging
 wasm-logger = "0.2.0" # Using this instead of Gloo because we already use log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ COPY --chown=aardwolf:aardwolf ./config/example.toml /app/aardwolf.toml
 #RUN cargo build --bin setup 
 
 # Copy the entrypoint and make it executable.
-COPY --chown=aardwolf:aardwolf docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chown=aardwolf:aardwolf ./docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod  u=rx,g=rx,o=rx /usr/local/bin/docker-entrypoint.sh
 
 # Expose the default port. This is often overridden in Docker CLI or Kubernetes.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ COPY --chown=aardwolf:aardwolf ./config/example.toml /app/aardwolf.toml
 #RUN cargo build --bin setup 
 
 # Copy the entrypoint and make it executable.
-COPY --chown=aardwolf:aardwolf ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chown=aardwolf:aardwolf docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod  u=rx,g=rx,o=rx /usr/local/bin/docker-entrypoint.sh
 
 # Expose the default port. This is often overridden in Docker CLI or Kubernetes.


### PR DESCRIPTION
**Description**: This PR addresses a issues that were preventing the Docker image from building successfully.

**before**: The build command was not specifying the correct context folder where the Dockerfile and related scripts are located giving error. `ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory`

**after**: Updated the Docker build command to set the context correctly to the docker directory.

### new issue found:
 After addressing the above issues, a new error has arisen related to the entry point script. During the build process, Docker throws an error indicating that docker-entrypoint.sh cannot be found.
`ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref f45fc31b-ef18-4a5f-be2b-7f841a08fbe4::1voajrdg166rvuhs16k60a5b1: "/docker-entrypoint.sh": not found
Error: Process completed with exit code 1.`

The error message indicates that the Docker build process is unable to find the docker-entrypoint.sh file. Based on the Dockerfile content and the directory structure, it appears that the docker-entrypoint.sh file is in the same directory as the Dockerfile. However, the COPY instruction in the Dockerfile is trying to copy it from the root directory. 

would u like me to update the dockerfile with correct path as well? also please add the hacktoberfest-accepted tag if possible 